### PR TITLE
Fix buffer leaks in MirroringHandler

### DIFF
--- a/AkhterAirPlayReceiver/app/src/main/java/com/github/serezhka/jap2server/internal/handler/mirroring/MirroringHandler.java
+++ b/AkhterAirPlayReceiver/app/src/main/java/com/github/serezhka/jap2server/internal/handler/mirroring/MirroringHandler.java
@@ -174,4 +174,14 @@ public class MirroringHandler extends SimpleChannelInboundHandler<ByteBuf> {
 
         dataConsumer.onVideo(spsPps);
     }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        headerBuf.release();
+        if (payload != null) {
+            payload.release();
+            payload = null;
+        }
+        super.handlerRemoved(ctx);
+    }
 }


### PR DESCRIPTION
## Summary
- release buffers when the MirroringHandler is removed

## Testing
- `./gradlew test --no-daemon --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f037fffc8325a63069c041173bb7