### PR TITLE
Fix volume parsing in RTSP

### DIFF
--- a/AkhterAirPlayReceiver/app/src/main/java/com/github/serezhka/jap2lib/RTSP.java
+++ b/AkhterAirPlayReceiver/app/src/main/java/com/github/serezhka/jap2lib/RTSP.java
@@ -212,7 +212,13 @@ class RTSP {
         // ios 音量 -30----》0由小变大
         int volume = -15;
         try {
-            volume = (int) Float.parseFloat(data.split(":")[1]);
+            String[] parts = data.split(":");
+            if (parts.length < 2) {
+                log.warn("Invalid volume parameter format: {}", data);
+                Log.w(TAG, "Invalid volume parameter format: " + data);
+                return volume;
+            }
+            volume = (int) Float.parseFloat(parts[1]);
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
## Summary
- prevent array index exceptions in `getSetParameterVolume`

## Testing
- `./AkhterAirPlayReceiver/gradlew test -p AkhterAirPlayReceiver --no-daemon --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f07559808325af3f14b93c691b3c